### PR TITLE
Syck 1.3.0

### DIFF
--- a/rails2_ruby2.gemspec
+++ b/rails2_ruby2.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  spec.add_dependency "syck", "~> 1.0.5"
+  spec.add_dependency "syck", "~> 1.3.0"
   spec.add_dependency 'iconv'
   spec.add_dependency 'test-unit', '1.2.3'
 


### PR DESCRIPTION
Necessary for Ruby 2.4.x compatibility: https://github.com/ruby/syck/blob/master/CHANGELOG.rdoc#120--2016-11-12