### PR TITLE
add patch to support default values that are negative integers

### DIFF
--- a/lib/rails2_ruby2/active_record/postgresql_column.rb
+++ b/lib/rails2_ruby2/active_record/postgresql_column.rb
@@ -1,0 +1,15 @@
+require 'active_record/connection_adapters/postgresql_adapter'
+
+ActiveRecord::ConnectionAdapters::PostgreSQLColumn.class_eval do
+  class << self
+    def extract_value_from_default_with_negative_integer_support(default)
+      if default =~ /\A'(-?\d+(\.\d*)?\)?)'::integer\z/i
+        $1
+      else
+        extract_value_from_default_without_negative_integer_support
+      end
+    end
+
+    alias_method_chain :extract_value_from_default, :negative_integer_support
+  end
+end

--- a/lib/rails2_ruby2/version.rb
+++ b/lib/rails2_ruby2/version.rb
@@ -1,3 +1,3 @@
 module Rails2Ruby2
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
# What this PR does
- Add patch to support default values (e.g. `-1::integer`) that are negative integers for Postgres >10.5
- This fixes a failing active record test
https://github.com/makandra/rails/blob/21025768e58918189d1f87f252eaabfa21f1e0f7/activerecord/test/cases/defaults_test.rb#L27
- bumps version to 1.0.1
# Notable things
- This patch was previously in the Rails2 repository and is being moved out to keep all patches together in the rails2_ruby2 project