### PR TITLE
Pass along default column value and release 1.0.2

### DIFF
--- a/lib/rails2_ruby2/active_record/postgresql_column.rb
+++ b/lib/rails2_ruby2/active_record/postgresql_column.rb
@@ -6,7 +6,7 @@ ActiveRecord::ConnectionAdapters::PostgreSQLColumn.class_eval do
       if default =~ /\A'(-?\d+(\.\d*)?\)?)'::integer\z/i
         $1
       else
-        extract_value_from_default_without_negative_integer_support
+        extract_value_from_default_without_negative_integer_support(default)
       end
     end
 

--- a/lib/rails2_ruby2/version.rb
+++ b/lib/rails2_ruby2/version.rb
@@ -1,3 +1,3 @@
 module Rails2Ruby2
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
# What this PR does

This PR makes sure to pass along the default value to PostgreSQLColumn#extract_value_from_default

Looks like we missed this when converting from Module#prepend with super to alias_method_chain back on PR #5 . 🤦‍♂️ 

# Notable things

* This bumps the gem version to 1.0.2 and will require a release